### PR TITLE
use correct key and remove service

### DIFF
--- a/manifests/windows_install.pp
+++ b/manifests/windows_install.pp
@@ -32,5 +32,13 @@ class sal_client::windows_install {
       ensure  => file,
       content => sorted_json($merged, true, 2)
     }
+
+    scheduled_task { 'sal':
+      ensure  => present,
+      command => "${install_dir}/Gosal.exe",
+      enabled => true,
+      trigger => [{'minutes_duration' => '25000000', 'minutes_interval' => '30', 'schedule' => 'once', 'start_date' => '1999-9-9', 'start_time' => '04:00'}],
+      user    => 'system',
+    }
   }
 }

--- a/manifests/windows_install.pp
+++ b/manifests/windows_install.pp
@@ -4,7 +4,7 @@ class sal_client::windows_install {
   $source = $sal_client::source
   $gosal  = $sal_client::gosal_version
 
-  $hash = Hash(['key',$key,'server',$server])
+  $hash = Hash(['key',$key,'url',$server])
 
   if $sal_client::gosal_config {
     $gosal_config = lookup('sal_client::gosal_config')
@@ -31,14 +31,6 @@ class sal_client::windows_install {
     file { "${install_dir}/config.json":
       ensure  => file,
       content => sorted_json($merged, true, 2)
-    }
-
-    scheduled_task { 'sal':
-      ensure  => present,
-      command => "${install_dir}/Gosal.exe",
-      enabled => true,
-      trigger => [{'minutes_duration' => '25000000', 'minutes_interval' => '30', 'schedule' => 'once', 'start_date' => '1999-9-9', 'start_time' => '04:00'}],
-      user    => 'system',
     }
   }
 }


### PR DESCRIPTION
@grahamgilbert PTAL

this fixes the config writing an incorrect key.  the key is not `server` its `url`.

also, i want to remove this module creating the windows scheduled task.  we shouldn't assume thats how any one admin wants to do this.  plus, puppet's built in scheduled task for windows doesn't expose all of the api - there is way more functionality in the gui.  this isn't a failure on puppet, just how windows works.

i'll prepare another PR in the future that uses a provider for installing windows scheduled tasks via xml import, which is more robust way to do it.