### PR TITLE
Add Debian os provider for gosal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # puppet-sal_client
+
 Configuration of a Sal client using Puppet.
 
 ## Usage
@@ -21,6 +22,7 @@ sal_client::basic_auth: true
 # Organisation name displayed in the profile. Cosmetic.
 sal_client::payload_organization: 'Sal Opensource'
 ```
+
 ### Optional Usage (Windows)
 
 if you're installing the windows client for sal (gosal) you'll need to create a yaml representation of gosal's config file in hiera.  Here, the `management` key is optional if you want to send facter data to sal.
@@ -33,9 +35,22 @@ sal_client::gosal_config:
     command: facts # the command used as an argument to the path/tool
 ```
 
+### Optional Usage (Debian)
+
+if you're installing the debian client for sal (gosal) you'll need to create a yaml representation of gosal's config file in hiera.  Here, the `management` key is optional if you want to send facter data to sal.
+
+```yaml
+sal_client::gosal_config:
+  management:
+    tool: puppet # tells gosal which config management tool you're using
+    path: /opt/puppetlabs/bin/puppet # tells gosal where the path to said tool is
+    command: facts # the command used as an argument to the path/tool
+```
 
 ## Requirements
+
 * [stdlib](https://github.com/puppetlabs/puppetlabs-stdlib)
 * [client_stdlib](https://github.com/macadmins/puppet-client_stdlib)
 * [mac_profiles_handler](https://github.com/keeleysam/puppet-mac_profiles_handler)
 * [win_scheduled_task](https://github.com/bdemetris/puppet-win_scheduled_task) - windows only
+

--- a/manifests/debian_install.pp
+++ b/manifests/debian_install.pp
@@ -1,0 +1,42 @@
+class sal_client::debian_install {
+  $server = $sal_client::server
+  $key    = $sal_client::key
+  $source = $sal_client::source
+  $gosal  = $sal_client::gosal_version
+
+  $hash = Hash(['key',$key,'url',$server])
+
+  if $sal_client::gosal_config {
+    $gosal_config = lookup('sal_client::gosal_config')
+    $merged = deep_merge($hash, $gosal_config)
+  } else {
+    $merged = $hash
+  }
+
+  $install_dir = '/opt/sal'
+
+  file { $install_dir:
+    ensure => 'directory',
+  }
+
+  file { "${install_dir}/gosal":
+    ensure  => 'file',
+    mode    => '0750',
+    owner   => 'root',
+    group   => 'root',
+    source => "${source}/${gosal}"
+  }
+
+  file { "${install_dir}/config.json":
+    ensure  => file,
+    content => sorted_json($merged, true, 2)
+  }
+
+  cron { 'SalCheckin':
+    command => '/opt/sal/gosal --config /opt/sal/config.json',
+    user    => 'root',
+    hour    => '*',
+    minute  => '*/15',
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,7 +14,7 @@ class sal_client (
   $http_username,
   $http_password
 ){
-  case $facts['os']['name'] {
+  case $facts['os']['family'] {
     'Darwin': {
       class {'sal_client::install': }
       -> class {'sal_client::config': }
@@ -23,6 +23,10 @@ class sal_client (
     }
     'Windows': {
       class {'sal_client::windows_install': }
+      -> Class['sal_client']
+    }
+    'Debian': {
+      class {'sal_client::debian_install': }
       -> Class['sal_client']
     }
   }


### PR DESCRIPTION
Add's a simple Debian provider which reflects the existing gosal for windows install.

Opted for a Cron as it's doesn't require any additional puppet modules. 