### PR TITLE
Add option to disable passing plist as binary to avoid PSON render

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ sal_client::basic_auth: true
 sal_client::payload_organization: "Sal Opensource"
 # Control whether to submit Puppet state when using puppet_checkin_module
 sal_client::report_puppet_state: false
+# Control whether to define the plist content as binary, Optional default True, can cause older versions of puppet to crash if set to False.
+sal_client::use_binary_plist: true
 ```
 
 ### Optional Usage (Windows)

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,6 +12,7 @@ sal_client::macos_receipt: "com.github.salopensource.sal_scripts"
 sal_client::http_username: ""
 sal_client::http_password: ""
 sal_client::report_puppet_state: true
+sal_clinet::use_binary_plist: true
 # example gosal config - management key is optional
 # sal_client::gosal_config:
 #   management:

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -12,7 +12,7 @@ sal_client::macos_receipt: "com.github.salopensource.sal_scripts"
 sal_client::http_username: ""
 sal_client::http_password: ""
 sal_client::report_puppet_state: true
-sal_clinet::use_binary_plist: true
+sal_client::use_binary_plist: true
 # example gosal config - management key is optional
 # sal_client::gosal_config:
 #   management:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -6,6 +6,7 @@ class sal_client::config {
   $basic_auth = $sal_client::basic_auth
   $payload_organization = $sal_client::payload_organization
   $report_puppet_state = $sal_client::report_puppet_state
+  $use_binary_plist = $sal_client::use_binary_plist
 
   $profile = {
     'PayloadContent' => [
@@ -44,9 +45,19 @@ class sal_client::config {
     'PayloadVersion' => 1
   }
 
-  mac_profiles_handler::manage { 'com.github.salopensource.sal':
-    ensure      => present,
-    file_source => plist($profile),
-    type        => 'template',
+  # We use binary by default to prevent the content of the plist being logged, as
+  # older verisons of puppet can crash with content large bodies being passed to the logs.    
+  if $use_binary_plist  {
+    mac_profiles_handler::manage { 'com.github.salopensource.sal':
+      ensure      => present,
+      file_source => plist($profile, binary),
+      type        => 'template',
+    }
+  } else  {
+    mac_profiles_handler::manage { 'com.github.salopensource.sal':
+      ensure      => present,
+      file_source => plist($profile),
+      type        => 'template',
+    }
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ class sal_client::config {
 
   mac_profiles_handler::manage { 'com.github.salopensource.sal':
     ensure      => present,
-    file_source => plist($profile, binary),
+    file_source => plist($profile),
     type        => 'template',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -14,6 +14,7 @@ class sal_client (
   $http_username,
   $http_password,
   $report_puppet_state,
+  $use_binary_plist = true
 ){
   case $facts['os']['family'] {
     'Darwin': {


### PR DESCRIPTION
Hey 👋 ,

I found that the binary argument in `file_source => plist($profile, binary)` seems unnecessary. Including it causes the Puppet-generated catalog to contain binary info, which can make the JSON compile fail and fall back to PSON which is now deprecated.

I've tested it without the binary argument, and everything seems to work fine, Looking at `puppet-munki` which does not use binary there is no reported issues with using this method.  https://github.com/airbnb/puppet-munki/blob/92598857d676a4d48e05501b23a6a9664c5b7c2e/manifests/config.pp#L112-L116

However, I might be missing some context for why it's there in the first place. If anyone knows the reason or believes this will cause an issues, please let me know.



